### PR TITLE
Fix for always "You win" message after guessing one correct

### DIFF
--- a/server.py
+++ b/server.py
@@ -108,6 +108,7 @@ class TCPHandler(socketserver.BaseRequestHandler):
         print(f"{client_id} joined")
         try:
             while True:
+                TCPHandler.success = False
                 data: dict[str, Any] = loads(self.request.recv(1024).decode('ascii'))
                 if data["quit"]:
                     TCPHandler.alive = False


### PR DESCRIPTION
There is a bug where you constantly get "You win" messages if you guess the correct one, even though you guess wrong, you will get a "You win" message no matter what. It is fixed on this pull.