### PR TITLE
Use GetSystemMetrics in win32api to get new resolution

### DIFF
--- a/server.py
+++ b/server.py
@@ -5,8 +5,10 @@ from time import time, sleep
 from math import cos, sin, pi
 from random import choice, seed
 from random import randint
+from win32api import GetSystemMetrics
 
-SC_WIDTH, SC_HEIGHT = 1920, 1080
+
+SC_WIDTH, SC_HEIGHT = GetSystemMetrics(0), GetSystemMetrics(1)
 W_WIDTH, W_HEIGHT = 150, 150
 SPACING = 100
 DO_TIMES = 30

--- a/server.py
+++ b/server.py
@@ -7,7 +7,6 @@ from random import choice, seed
 from random import randint
 from win32api import GetSystemMetrics
 
-
 SC_WIDTH, SC_HEIGHT = GetSystemMetrics(0), GetSystemMetrics(1)
 W_WIDTH, W_HEIGHT = 150, 150
 SPACING = 100


### PR DESCRIPTION
Small screen requires small resolution, but by default, 1920 x 1080 is used.
With GetSystemMetrics, I can now set a new resolution rather than a default 1920 x 1080, just to be sure that the game is right at the middle of the screen.