### PR TITLE
Fix spawn-all.py to use either python or python3

### DIFF
--- a/spawn-all.py
+++ b/spawn-all.py
@@ -8,7 +8,7 @@ counted = 0
 
 def threadeded():
     global counted
-    system("python3 main.py")
+    system("python main.py")
     counted -= 1
 
 

--- a/spawn-all.py
+++ b/spawn-all.py
@@ -1,14 +1,18 @@
+from shutil import which
 from os import system
 from _thread import start_new_thread
 from time import sleep
 
+w1 = which("python")
+w2 = which("python3")
+cmd = "python" if (w2==None or (w1!=None and ("WindowsApps" in w2))) else "python3"
 
 counted = 0
 
 
 def threadeded():
     global counted
-    system("python main.py")
+    system(cmd+" main.py")
     counted -= 1
 
 


### PR DESCRIPTION
just a suggestion, I have an installation from python.org and `python3` triggers microsoft store.
please test if `python` works though so that microsoft store users suddenly can't run this