### PR TITLE
Fixed spawn-all.py using python3 from MINGW64

### DIFF
--- a/spawn-all.py
+++ b/spawn-all.py
@@ -5,7 +5,7 @@ from time import sleep
 
 w1 = which("python")
 w2 = which("python3")
-if (w2 is None) or (w1 is not None and (("WindowsApps" in w2) or ("mingw64" in w2))):
+if (w2 is None) or (w1 and (("WindowsApps" in w2) or ("mingw64" in w2))):
     cmd = "python"
 else:
     cmd = "python3"

--- a/spawn-all.py
+++ b/spawn-all.py
@@ -5,7 +5,7 @@ from time import sleep
 
 w1 = which("python")
 w2 = which("python3")
-cmd = "python" if (w2==None or (w1!=None and ("WindowsApps" in w2))) else "python3"
+cmd = "python" if (w2 is None or (w1 is not None and ("WindowsApps" in w2))) else "python3"
 
 counted = 0
 

--- a/spawn-all.py
+++ b/spawn-all.py
@@ -5,7 +5,10 @@ from time import sleep
 
 w1 = which("python")
 w2 = which("python3")
-cmd = "python" if (w2 is None or (w1 is not None and ("WindowsApps" in w2))) else "python3"
+if (w2 is None) or (w1 is not None and ("WindowsApps" in w2)):
+    cmd = "python"
+else:
+    cmd = "python3"
 
 counted = 0
 

--- a/spawn-all.py
+++ b/spawn-all.py
@@ -5,7 +5,7 @@ from time import sleep
 
 w1 = which("python")
 w2 = which("python3")
-if (w2 is None) or (w1 is not None and ("WindowsApps" in w2)):
+if (w2 is None) or (w1 is not None and (("WindowsApps" in w2) or ("mingw64" in w2))):
     cmd = "python"
 else:
     cmd = "python3"

--- a/spawn-all.py
+++ b/spawn-all.py
@@ -3,9 +3,9 @@ from os import system
 from _thread import start_new_thread
 from time import sleep
 
-w1 = which("python")
-w2 = which("python3")
-if (w2 is None) or (w1 and (("WindowsApps" in w2) or ("mingw64" in w2))):
+python_path = which("python")
+python3_path = which("python3")
+if (python3_path is None) or (python_path and (("WindowsApps" in python3_path) or ("mingw64" in python3_path))):
     cmd = "python"
 else:
     cmd = "python3"


### PR DESCRIPTION
If a Windows system has [MINGW64](https://www.mingw-w64.org/) with Python3 installed along with the "regular" Python, `spawn-all.py` will use MINGW64's Python3 by default with `cmd = "python3"`

It may cause such issues as `ModuleNotFoundError: No module named 'pygame'` despite the fact that you've installed requirements in your "correct" Python. And if you try to install the requirements through "python3" command you may get this error:
```
PS D:\<REDACTED>\limbos32> python3 -m pip install -r .\requirements.txt
C:\msys64\mingw64\bin\python3.exe: No module named pip
```
Fixing this in code is way more convenient than trying to resolve `ModuleNotFoundError` exception through installing `pip` module for MINGW64's Python via its shell.